### PR TITLE
Move scratch to examples

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -1,0 +1,3 @@
+{:paths ["src" "resources"]
+ :deps {org.clojure/clojure {:mvn/version "1.8.0"}
+        selfsame/pdfn {:mvn/version "1.0.3"}}}

--- a/examples/scratch.cljc
+++ b/examples/scratch.cljc
@@ -1,5 +1,5 @@
 (ns tenlet.scratch
-  (:require 
+  (:require
     [tenlet.server :refer [write close create-server DEBUG]]
     [tenlet.escape :as esc]))
 
@@ -28,14 +28,14 @@
 (defn player-resize [c m]
   (let [{:keys [w h]} m]
     (write c esc/CLR)
-    (dorun 
+    (dorun
       (for [x (range (inc w))
             y (range (inc h))
             :when (or (#{2 (dec w)} x) (#{2 (dec h)} y))]
-      (do 
+      (do
         (write c (esc/cursor x y))
-        (write c (str 
-          (esc/background (rand-nth (vec esc/color-names))) 
+        (write c (str
+          (esc/background (rand-nth (vec esc/color-names)))
           (esc/code (rand-nth (vec esc/color-names)))))
         (write c (char (+ 33 (rand-int 93)))))))
     (write c (esc/cursor (int (/ w 2)) (int (/ h 2))))
@@ -44,15 +44,15 @@
 (declare server)
 
 (defn shutdown! []
-  (write server (str  
+  (write server (str
     (esc/background :white) (esc/code :red)
     "\nSERVER SHUTTING DOWN\n"
     (esc/code :reset)))
   (close server))
 
-(if server (shutdown!))
+;; (if server (shutdown!))
 
-(def server 
+(def server
   (create-server 5071 {
     :connect  #'new-player
     :line     #'player-input
@@ -65,14 +65,14 @@
 
 
 
-(for [i (range 20)] 
-  (broad! 
-    (esc/background (rand-nth (vec esc/color-names))) 
+(for [i (range 20)]
+  (broad!
+    (esc/background (rand-nth (vec esc/color-names)))
     (esc/code (rand-nth (vec esc/color-names)))
     'selfsame (esc/code :reset)))
 
 '(for [i (range 20)]
-  (do 
+  (do
     (broad! (cursor i i))
     (broad! (code (rand-nth (vec color-names))))
     (broad! "@")))

--- a/project.clj
+++ b/project.clj
@@ -3,9 +3,8 @@
   :url "http://github.com/selfsame/tenlet"
   :license {:name "The MIT License (MIT)"
             :url "https://github.com/selfsame/pdfn/blob/master/LICENSE"}
-  :dependencies [
-    [org.clojure/clojure "1.8.0"]
-    [selfsame/pdfn "1.0.3"]]
+  ;; use deps from deps.edn
+  :plugins [[lein-tools-deps "0.4.5"]]
   :deploy-repositories [
     ["clojars" {
       :sign-releases false}]])

--- a/src/tenlet/server.cljc
+++ b/src/tenlet/server.cljc
@@ -1,4 +1,3 @@
-
 (ns tenlet.server
   (:require
     [tenlet.decode :as decode])

--- a/src/tenlet/server.cljc
+++ b/src/tenlet/server.cljc
@@ -1,7 +1,8 @@
+
 (ns tenlet.server
   (:require
     [tenlet.decode :as decode])
-  #?(:clj (import 
+  #?(:clj (:import
             [java.net ServerSocket Socket SocketException]
             [java.io InputStreamReader OutputStreamWriter BufferedWriter]
             [java.nio.charset Charset])))
@@ -36,7 +37,7 @@
   ITelnet
   (connect [o c]
     (swap! opts update :clients conj c))
-  (write [o s] 
+  (write [o s]
     (dorun (map #(write % s) (:clients @opts))))
   (close [o]
     (dorun (map close (:clients @opts)))
@@ -45,25 +46,25 @@
 (deftype Client [socket ow opts]
   ITelnet
   (connect [o] (call @opts :connect o))
-#?(:clj 
+#?(:clj
   (write [o s]
-    (try 
-      (.write ow (str s)) 
+    (try
+      (.write ow (str s))
       (.flush ow)
       (catch Exception e)))
   :cljs
-  (write [o s] 
-    (try 
+  (write [o s]
+    (try
       (.write socket (str s) "latin1")
       (catch :default e))))
-  (input [o c] 
+  (input [o c]
     (debug [c (int c)])
     (let [code (decode/op (or (::code @opts) {}) c)
           out (:out code)
           -line (:line code)
           resize (:resize code)]
       (debug :code code)
-      (when resize 
+      (when resize
         (call @opts :resize o resize)
         (swap! opts assoc ::code (dissoc code :resize)))
       (when out
@@ -75,33 +76,33 @@
       (if-not (or out -line resize)
         (swap! opts assoc ::code code))))
   (line [o s] (call @opts :line o s))
-  (close [o] 
-    (swap! (.-opts (::server @opts)) update :clients 
+  (close [o]
+    (swap! (.-opts (::server @opts)) update :clients
       #(-> % set (disj o) seq))
-    #?(:clj  
-        (try 
+    #?(:clj
+        (try
           (.close socket)
           (call @opts :close o)
           (catch Exception e))
-       :cljs 
-        (try 
+       :cljs
+        (try
           (.destroy socket)
           (catch :default e)))))
 
 (defn- new-connection [S c opts]
- #?(:clj 
-    (on-thread 
-      (fn [] 
-        (let [i (. c (getInputStream)) 
+ #?(:clj
+    (on-thread
+      (fn []
+        (let [i (. c (getInputStream))
               o (. c (getOutputStream))
               ir (new InputStreamReader i iso-latin-1)
               ow (new OutputStreamWriter o iso-latin-1)
               C (Client. c ow (atom opts))]
           (connect S C)
           (connect C)
-          ((fn [] 
+          ((fn []
             (when-not (.isClosed c)
-              (try 
+              (try
                 (input C (char (.read ir)))
                 (catch java.lang.IllegalArgumentException e
                   (close C))
@@ -113,20 +114,20 @@
       (connect S C)
       (connect C)
       (.on c "data" (fn [d] (dorun (map #(input C %) (str d)))))
-      (.on c "close" 
-        (fn [e] 
+      (.on c "close"
+        (fn [e]
           (close C)
           (call @(.-opts C) :close C))))))
 
 (defn create-server [port opts]
- #?(:clj 
+ #?(:clj
     (let [s (new ServerSocket port)
           S (Server. s (atom {}))
           opts (assoc opts ::server S)]
-      (on-thread 
-        (fn [] 
+      (on-thread
+        (fn []
           (when-not (.isClosed s)
-            (try 
+            (try
               (let [c (.accept s)]
                 (new-connection S c opts))
               (catch SocketException e
@@ -136,8 +137,8 @@
     (let [s ((.-createServer net))
           S (Server. s (atom {}))
           opts (assoc opts ::server S)]
-      (.listen s port) 
-      (.on s "connection" (fn [c] 
+      (.listen s port)
+      (.on s "connection" (fn [c]
         (new-connection S c opts)))
-      (.on s "close" 
+      (.on s "close"
         (fn [e] (call opts :shutdown S))) S)))


### PR DESCRIPTION
Something in `scratch` won't let me use this as a deps "checkout" in my CLJ project. Since it seems to be an example on how to use tenlet I moved it to examples to avoid the issue.

Based on #2 and #3 